### PR TITLE
Run example with podman on MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ python run.py \
   --task_config_path tasks/battleOfSexes.yaml \
   --model litellm:claude-3-5-sonnet-20240620 \
   --per_instance_cost_limit 4.00 \
-  --config_file configs/agents/default.yaml \
+  --agent_config_path configs/agents/default.yaml \
   --temp 1 \
   --gpus 0 \
   --max_steps 50 \
@@ -152,7 +152,7 @@ python run.py \
   --task_config_path tasks/battleOfSexes.yaml \
   --model litellm:claude-3-5-sonnet-20240620 \
   --per_instance_cost_limit 4.00 \
-  --config_file configs/agents/default.yaml \
+  --agent_config_path configs/agents/default.yaml \
   --temp 1 \
   --gpus 0 \
   --max_steps 50 \

--- a/README.md
+++ b/README.md
@@ -59,12 +59,11 @@ This is the first Gym environment for machine learning (ML) tasks, enabling rese
     ANTHROPIC_API_KEY=""
     ```
 
-3. You can use Docker or Podman to run the tasks inside the container. Podman is a recommended way of running
-a container in MacOS.
+3. You can use either Docker or Podman to run tasks inside a container. Podman is the recommended way to run containers on macOS.
 
-4. Follow the instructions [here](https://docs.docker.com/desktop/) to install docker. Choose the appropriate install command depending on your OS.
+4. Follow the instructions [here](https://docs.docker.com/desktop/) to install docker. Select the appropriate installation command based on your OS.
 
-5. If you are working on a linux machine, please install the `nvidia-container-runtime`. This is required to start docker containers with GPU support.
+5. If you are working on a Linux machine, please install the `nvidia-container-runtime`. This is required to start docker containers with GPU support.
 
     ```bash
     sudo dnf install -y nvidia-container-toolkit
@@ -89,8 +88,8 @@ a container in MacOS.
     ```
 
 8. For MacOS:  
-    a. If you're familiar with brew package manager, install podman with `brew install podman`. Otherwise follow the instructions [here](https://podman.io/get-started).  
-    b. Start the podman machine and set the socket env var:
+    a. If you use Homebrew package manager, install Podman with `brew install podman`. Otherwise, follow the instructions [here](https://podman.io/get-started).  
+    b. Start the podman machine and set the docker host env variable:
     ```bash
     podman machine init
     podman machine start

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ This is the first Gym environment for machine learning (ML) tasks, enabling rese
     ```bash
     podman machine init
     podman machine start
-    export DOCKER_HOST=http+unix://$(podman machine inspect --format '{{.ConnectionInfo.PodmanSocket.Path}}')
+    export DOCKER_HOST=unix://$(podman machine inspect --format '{{.ConnectionInfo.PodmanSocket.Path}}')
     ```
 
 9. Pull the container image:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ This is the first Gym environment for machine learning (ML) tasks, enabling rese
     ```bash
     git clone git@github.com:facebookresearch/MLGym.git
     cd MLGym
-    conda create -n mlgym python=3.11
+    conda create -y -n mlgym python=3.11
+    conda activate mlgym
     pip install -e .
     ```
 
@@ -58,17 +59,22 @@ This is the first Gym environment for machine learning (ML) tasks, enabling rese
     ANTHROPIC_API_KEY=""
     ```
 
-3. Follow the instructions [here](https://docs.docker.com/desktop/) to install docker. Choose the appropriate install command depending on your OS.
+3. You can use Docker or Podman to run the tasks inside the container. Podman is a recommended way of running
+a container in MacOS.
 
-4. If you are working on a linux machine, please install the `nvidia-container-runtime`. This is required to start docker containers with GPU support.
+4. Follow the instructions [here](https://docs.docker.com/desktop/) to install docker. Choose the appropriate install command depending on your OS.
+
+5. If you are working on a linux machine, please install the `nvidia-container-runtime`. This is required to start docker containers with GPU support.
 
     ```bash
     sudo dnf install -y nvidia-container-toolkit
     ```
 
-5. **Please skip to step 9 if you don't want to use Podman**.
-6. Follow the instructions [here](https://podman.io/get-started) to install Podman.
-7. Start podman socket. The last command should return a running podman socket.
+6. **Please skip to step 9 if you don't want to use Podman**.
+
+7. For Linux:  
+    a. Follow the instructions [here](https://podman.io/get-started) to install Podman.  
+    b. Start podman socket. The last command should return a running podman socket:
 
     ```bash
     systemctl --user enable podman.socket
@@ -76,16 +82,30 @@ This is the first Gym environment for machine learning (ML) tasks, enabling rese
     systemctl --user status podman.socket 
     ```
 
-8. Redirect docker host to podman by exporting docker host env variable in bashrc or current session.
+    c. Redirect docker host to podman by exporting docker host env variable in bashrc or current session:
 
     ```bash
     export DOCKER_HOST=unix:///run/user/$UID/podman/podman.sock
     ```
 
-9. Pull the docker container
+8. For MacOS:  
+    a. If you're familiar with brew package manager, install podman with `brew install podman`. Otherwise follow the instructions [here](https://podman.io/get-started).  
+    b. Start the podman machine and set the socket env var:
+    ```bash
+    podman machine init
+    podman machine start
+    export DOCKER_HOST=http+unix://$(podman machine inspect --format '{{.ConnectionInfo.PodmanSocket.Path}}')
+    ```
+
+9. Pull the container image:
 
     ```bash
     docker pull aigym/mlgym-agent:latest
+    ```
+
+    or  
+    ```bash
+    podman pull aigym/mlgym-agent:latest
     ```
 
 10. Test launching a docker/podman container with GPU support

--- a/mlgym/backend/litellm.py
+++ b/mlgym/backend/litellm.py
@@ -104,15 +104,19 @@ class LiteLLMModel(BaseModel):
         completion_kwargs = self.args.completion_kwargs
         if self.lm_provider == "anthropic":
             completion_kwargs["max_tokens"] = self.model_max_output_tokens
-        response: litellm.types.utils.ModelResponse = litellm.completion(  # type: ignore
-            model=self.model_name,
-            messages=messages,
-            temperature=self.args.temperature,
-            top_p=self.args.top_p,
-            api_version=self.args.api_version,
-            **completion_kwargs,
-            **extra_args,
-        )
+        try:
+            response: litellm.types.utils.ModelResponse = litellm.completion(  # type: ignore
+                model=self.model_name,
+                messages=messages,
+                temperature=self.args.temperature,
+                top_p=self.args.top_p,
+                api_version=self.args.api_version,
+                **completion_kwargs,
+                **extra_args,
+            )
+        except Exception as e:
+            self.logger.exception(f"Error during LLM query: {e}")
+            raise e
         choices: litellm.types.utils.Choices = response.choices # type: ignore
         output = choices[0].message.content or ""
         # output_dict = {"message": output}

--- a/mlgym/environment/env.py
+++ b/mlgym/environment/env.py
@@ -504,7 +504,12 @@ class MLGymEnv(gym.Env):
             if self.args.memory_enabled:
                 self.logger.info("Attempting to save memory before exiting container")
                 assert self.container_obj is not None
-                copy_anything_from_container(container=self.container_obj, host_path=str(self.task_args.memory_path), container_path=str(self.memory_path))
+                copy_anything_from_container(
+                    container=self.container_obj,
+                    container_type=self.container_type,
+                    host_path=str(self.task_args.memory_path),
+                    container_path=str(self.memory_path),
+                )
             
             self.communicate(input="exit")
 


### PR DESCRIPTION
Hi, thanks for releasing such a great tool for agentic research!
I've tried to run the Podman example from the readme and discovered a few issues during this process. This PR:
1. Adds missed conda env activation to the readme
2. Adds instructions on how to install and configure Podman on MacOS to the readme
3. Switches from using the `docker` command in the utils to the command defined by the `container_type` argument (either docker or podman)
4. Adds error logging in the litellm wrapper to log issues that occurred during the API calls.

With all these changes, I was able to successfully run the example on my MacBook.