### PR TITLE
Fix list out of index error for cases without baseline

### DIFF
--- a/mlgym/environment/env.py
+++ b/mlgym/environment/env.py
@@ -946,7 +946,11 @@ class MLGymEnv(gym.Env):
             elif action == "validate":
                 self.logger.info(f"Evaluation score: {metrics}")
                 info["score"].append(metrics)
-                observation = f"Your code produced a valid submission artefact at {submission}.\nBaseline Score: {self.task_args.baseline_scores[0]}\nEvaluation Score: {metrics}".strip()
+                try:
+                    baseline_sc = self.task_args.baseline_scores[0]
+                except(AttributeError,IndexError):
+                    baseline_sc = 'NA (no baseline was there)'
+                observation = f"Your code produced a valid submission artefact at {submission}.\nBaseline Score: {baseline_sc}\nEvaluation Score: {metrics}".strip()
                 return observation, 0, False, info
             else:
                 self.logger.warning(


### PR DESCRIPTION
When you don't provide a baseline, MLGym generally works but fails at this step of validation. This is becasue it tries to check baseline score when none exists.

The PR just does a minor check around the statement with a try/except.