### PR TITLE
Extract Configs/Args Clsses Into Separate Module

### DIFF
--- a/mlgym/agent/base.py
+++ b/mlgym/agent/base.py
@@ -3,10 +3,10 @@ Copyright (c) Meta Platforms, Inc. and affiliates.
 
 Base agent implementation for the MLGym framework.
 
-This module provides the core agent functionality including configuration,
-history tracking, model interaction, and environment communication. The agent
-is responsible for receiving observations from the environment, querying the
-model for actions, and executing those actions.
+This module provides the core agent functionality, history tracking, 
+model interaction, and environment communication. The agent is responsible
+for receiving observations from the environment, querying the model for 
+actions, and executing those actions.
 
 Adapted from SWE-Agent/sweagent/agent/agents.py
 """

--- a/mlgym/agent/base.py
+++ b/mlgym/agent/base.py
@@ -40,7 +40,7 @@ from mlgym.utils.config import convert_paths_to_abspath
 from mlgym.utils.log import get_logger, logging
 
 if TYPE_CHECKING:
-    from mlgym.backend.base import APIStats, ModelArguments
+    from mlgym.backend.base import APIStats, ModelConfig
     from mlgym.environment.env import MLGymEnv
     from mlgym.environment.tasks import TaskConfig
 
@@ -107,7 +107,7 @@ class AgentConfig(FlattenedAccess, FrozenSerializable):
 class AgentArguments(FlattenedAccess, FrozenSerializable):
     """Configure the agent's behaviour (templates, parse functions, ...)."""
 
-    model: ModelArguments
+    model: ModelConfig
 
     # Policy can only be set via config yaml file from command line
     agent_config_path: Path | str | None = None

--- a/mlgym/agent/base.py
+++ b/mlgym/agent/base.py
@@ -15,13 +15,10 @@ from __future__ import annotations
 
 import json
 import time
-from dataclasses import asdict, dataclass
+from dataclasses import asdict
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from simple_parsing.helpers.fields import field
-from simple_parsing.helpers.flatten import FlattenedAccess
-from simple_parsing.helpers.serialization.serializable import FrozenSerializable
 from tenacity import RetryError
 
 from mlgym.agent.history_processors import HistoryProcessor
@@ -34,94 +31,18 @@ from mlgym.exceptions import (
     CostLimitExceededError,
     FormatError,
 )
-from mlgym.tools.tools import ToolHandler, ToolsConfig
+from mlgym.tools.tools import ToolHandler
 from mlgym.types import AgentInfo, History, HistoryItem, Trajectory, TrajectoryStep
-from mlgym.utils.config import convert_paths_to_abspath
 from mlgym.utils.log import get_logger, logging
 
+from mlgym.agent.config import AgentConfig
+from mlgym.cli.arguments.agent import AgentArguments
+
 if TYPE_CHECKING:
-    from mlgym.backend.base import APIStats, ModelConfig
+    from mlgym.backend.base import APIStats
     from mlgym.environment.env import MLGymEnv
-    from mlgym.environment.tasks import TaskConfig
-
-
-@dataclass(frozen=True)
-class AgentConfig(FlattenedAccess, FrozenSerializable):
-    system_template: str
-    task_template: str
-    next_step_template: str | None = None  # defaults to task_template
-    next_step_no_output_template: str | None = None  # default to next_step template
-    strategy_template: str | None = None
-    demonstration_template: str | None = None
-    # Paths to demonstrations. If path is not absolute, it is assumed to be
-    # relaive to the MLGym repository root.
-    # FIXME: Migrate to pydantic under issue #19
-    demonstrations: list[str | Path] = field(default_factory=list)  # noqa: RUF009
-    # if True, add demonstration to history instead of as a single message
-    put_demos_in_history: bool = False
-    # defaults to format_error_template in ParseFunction
-    format_error_template: str | None = None
-    # Commands configuration with blocklist, env variables and util functions
-    # FIXME: Migrate to pydantic under issue #19
-    tools: ToolsConfig = field(default_factory=ToolsConfig)  # noqa: RUF009
-    output_parser: str | ParseFunction = "ThoughtActionParser"
-    history_processor: str = "DefaultHistoryProcessor"
-    # FIXME: Migrate to pydantic under issue #19
-    history_processor_args: dict[str, Any] = field(default_factory=dict)  # noqa: RUF009
-
-    def __post_init__(self) -> None:
-        object.__setattr__(self, "tools_handler", ToolHandler(self.tools))
-
-        object.__setattr__(self, "demonstrations", convert_paths_to_abspath(self.demonstrations))
-
-        if self.next_step_template is None:
-            object.__setattr__(self, "next_step_template", self.task_template)
-        if self.next_step_no_output_template is None:
-            object.__setattr__(self, "next_step_no_output_template", self.next_step_template)
-
-        if isinstance(self.output_parser, str):
-            object.__setattr__(self, "output_parser", ParseFunction.get(self.output_parser))
-        assert isinstance(self.output_parser, ParseFunction)
-
-        if self.format_error_template is None:
-            object.__setattr__(
-                self,
-                "format_error_template",
-                self.output_parser.format_error_template,
-            )
-        else:
-            object.__setattr__(
-                self,
-                "format_error_template",
-                self.format_error_template.format(**self.__dict__),
-            )
-
-        object.__setattr__(
-            self,
-            "history_processor",
-            HistoryProcessor.get(self.history_processor, **self.history_processor_args),
-        )
-
-
-@dataclass(frozen=True)
-class AgentArguments(FlattenedAccess, FrozenSerializable):
-    """Configure the agent's behaviour (templates, parse functions, ...)."""
-
-    model: ModelConfig
-
-    # Policy can only be set via config yaml file from command line
-    agent_config_path: Path | str | None = None
-    # FIXME: Migrate to pydantic under issue #19
-    config: AgentConfig | None = field(default=None, cmd=False)  # noqa: RUF009
-    log_verbose_to_console: bool = False
-
-    def __post_init__(self) -> None:
-        if self.config is None and self.agent_config_path is not None:
-            # If unassigned, we load the config from the file to store its contents with the overall arguments
-            config = AgentConfig.load_yaml(self.agent_config_path)
-            object.__setattr__(self, "config", config)
-        assert self.config is not None
-
+    
+    from mlgym.environment.task_config import TaskConfig
 
 class BaseAgent:
     """

--- a/mlgym/agent/config.py
+++ b/mlgym/agent/config.py
@@ -1,7 +1,9 @@
 """
 Copyright (c) Meta Platforms, Inc. and affiliates.
 
-Agent Configuration class for the MLGym framework.
+Config module for agent module.
+
+This module provides the configuration interface for the agent module.
 """
 
 from __future__ import annotations

--- a/mlgym/agent/config.py
+++ b/mlgym/agent/config.py
@@ -1,12 +1,7 @@
 """
 Copyright (c) Meta Platforms, Inc. and affiliates.
 
-Base agent implementation for the MLGym framework.
-
-This module provides the core agent functionality including configuration,
-history tracking, model interaction, and environment communication. The agent
-is responsible for receiving observations from the environment, querying the
-model for actions, and executing those actions.
+Agent Configuration class for the MLGym framework.
 """
 
 from __future__ import annotations

--- a/mlgym/agent/config.py
+++ b/mlgym/agent/config.py
@@ -1,0 +1,84 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+Base agent implementation for the MLGym framework.
+
+This module provides the core agent functionality including configuration,
+history tracking, model interaction, and environment communication. The agent
+is responsible for receiving observations from the environment, querying the
+model for actions, and executing those actions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from simple_parsing.helpers.fields import field
+from simple_parsing.helpers.flatten import FlattenedAccess
+from simple_parsing.helpers.serialization.serializable import FrozenSerializable
+
+from mlgym.agent.history_processors import HistoryProcessor
+from mlgym.agent.parsing import ParseFunction
+from mlgym.tools.tools import ToolHandler, ToolsConfig
+from mlgym.utils.config import convert_paths_to_abspath
+
+# agent/base.py
+@dataclass(frozen=True)
+class AgentConfig(FlattenedAccess, FrozenSerializable):
+    system_template: str
+    task_template: str
+    next_step_template: str | None = None  # defaults to task_template
+    next_step_no_output_template: str | None = None  # default to next_step template
+    strategy_template: str | None = None
+    demonstration_template: str | None = None
+    # Paths to demonstrations. If path is not absolute, it is assumed to be
+    # relaive to the MLGym repository root.
+    # FIXME: Migrate to pydantic under issue #19
+    demonstrations: list[str | Path] = field(default_factory=list)  # noqa: RUF009
+    # if True, add demonstration to history instead of as a single message
+    put_demos_in_history: bool = False
+    # defaults to format_error_template in ParseFunction
+    format_error_template: str | None = None
+    # Commands configuration with blocklist, env variables and util functions
+    # FIXME: Migrate to pydantic under issue #19
+    tools: ToolsConfig = field(default_factory=ToolsConfig)  # noqa: RUF009
+    output_parser: str | ParseFunction = "ThoughtActionParser"
+    history_processor: str = "DefaultHistoryProcessor"
+    # FIXME: Migrate to pydantic under issue #19
+    history_processor_args: dict[str, Any] = field(default_factory=dict)  # noqa: RUF009
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "tools_handler", ToolHandler(self.tools))
+
+        object.__setattr__(self, "demonstrations", convert_paths_to_abspath(self.demonstrations))
+
+        if self.next_step_template is None:
+            object.__setattr__(self, "next_step_template", self.task_template)
+        if self.next_step_no_output_template is None:
+            object.__setattr__(self, "next_step_no_output_template", self.next_step_template)
+
+        if isinstance(self.output_parser, str):
+            object.__setattr__(self, "output_parser", ParseFunction.get(self.output_parser))
+        assert isinstance(self.output_parser, ParseFunction)
+
+        if self.format_error_template is None:
+            object.__setattr__(
+                self,
+                "format_error_template",
+                self.output_parser.format_error_template,
+            )
+        else:
+            object.__setattr__(
+                self,
+                "format_error_template",
+                self.format_error_template.format(**self.__dict__),
+            )
+
+        object.__setattr__(
+            self,
+            "history_processor",
+            HistoryProcessor.get(self.history_processor, **self.history_processor_args),
+        )
+

--- a/mlgym/backend/base.py
+++ b/mlgym/backend/base.py
@@ -15,48 +15,19 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, fields
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, ClassVar
 
-from simple_parsing.helpers.fields import field
 from simple_parsing.helpers.serialization.serializable import (
-    FrozenSerializable,
     Serializable,
 )
 
 from mlgym.exceptions import CostLimitExceededError
 from mlgym.utils.log import get_logger
 
+from mlgym.backend.config import ModelConfig
+
 if TYPE_CHECKING:
     from mlgym.types import HistoryItem
-
-
-@dataclass(frozen=True)
-class ModelConfig(FrozenSerializable):
-    """Arguments configuring the model and it's behavior."""
-
-    # Name of the model to use
-    model_name: str
-    # Cost limit for every task
-    per_instance_cost_limit: float = 0.0
-    # Total cost limit
-    total_cost_limit: float = 0.0
-    # Sampling temperature
-    temperature: float = 1.0
-    # Sampling top_p
-    top_p: float = 1.0
-    # Path to replay file when using the replay model
-    replay_path: str | None = None
-    # api base url
-    host_url: str | None = None
-    # api version - specific to azure
-    api_version: str | None = None
-    # api key
-    api_key: str | None = None
-    # custom stop sequences
-    stop: list[str] = field(default_factory=list)  # noqa: RUF009
-    # additional kwargs to pass to litellm.completion
-    completion_kwargs: dict[str, Any] = field(default_factory=dict)  # noqa: RUF009
-
 
 @dataclass
 class APIStats(Serializable):

--- a/mlgym/backend/base.py
+++ b/mlgym/backend/base.py
@@ -3,9 +3,9 @@ Copyright (c) Meta Platforms, Inc. and affiliates.
 
 Base model implementation for the MLGym framework.
 
-This module provides the core model functionality including configuration,
-API interaction, and cost tracking. It defines the base classes and interfaces
-for different model types (OpenAI, Azure, Meta, etc.) and handles common
+This module provides the core model functionality, API interaction,
+and cost tracking. It defines the base classes and interfaces for
+different model types (OpenAI, Azure, Meta, etc.) and handles common
 operations like cost calculation and limit enforcement.
 
 Adapted from SWE-agent/sweagent/agent/models.py

--- a/mlgym/backend/base.py
+++ b/mlgym/backend/base.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 
 
 @dataclass(frozen=True)
-class ModelArguments(FrozenSerializable):
+class ModelConfig(FrozenSerializable):
     """Arguments configuring the model and it's behavior."""
 
     # Name of the model to use
@@ -123,7 +123,7 @@ class BaseModel(ABC):
     MODELS: ClassVar = {}
     SHORTCUTS: ClassVar = {}
 
-    def __init__(self, args: ModelArguments) -> None:
+    def __init__(self, args: ModelConfig) -> None:
         """
         Initialize the model with configuration arguments.
 

--- a/mlgym/backend/config.py
+++ b/mlgym/backend/config.py
@@ -1,0 +1,47 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+Base model implementation for the MLGym framework.
+
+This module provides the core model functionality including configuration,
+API interaction, and cost tracking. It defines the base classes and interfaces
+for different model types (OpenAI, Azure, Meta, etc.) and handles common
+operations like cost calculation and limit enforcement.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from simple_parsing.helpers.fields import field
+from simple_parsing.helpers.serialization.serializable import (
+    FrozenSerializable,
+)
+
+@dataclass(frozen=True)
+class ModelConfig(FrozenSerializable):
+    """Arguments configuring the model and it's behavior."""
+
+    # Name of the model to use
+    model_name: str
+    # Cost limit for every task
+    per_instance_cost_limit: float = 0.0
+    # Total cost limit
+    total_cost_limit: float = 0.0
+    # Sampling temperature
+    temperature: float = 1.0
+    # Sampling top_p
+    top_p: float = 1.0
+    # Path to replay file when using the replay model
+    replay_path: str | None = None
+    # api base url
+    host_url: str | None = None
+    # api version - specific to azure
+    api_version: str | None = None
+    # api key
+    api_key: str | None = None
+    # custom stop sequences
+    stop: list[str] = field(default_factory=list)  # noqa: RUF009
+    # additional kwargs to pass to litellm.completion
+    completion_kwargs: dict[str, Any] = field(default_factory=dict)  # noqa: RUF009

--- a/mlgym/backend/config.py
+++ b/mlgym/backend/config.py
@@ -1,12 +1,9 @@
 """
 Copyright (c) Meta Platforms, Inc. and affiliates.
 
-Base model implementation for the MLGym framework.
+Config module for backend module.
 
-This module provides the core model functionality including configuration,
-API interaction, and cost tracking. It defines the base classes and interfaces
-for different model types (OpenAI, Azure, Meta, etc.) and handles common
-operations like cost calculation and limit enforcement.
+This module provides the configuration interface for the model module.
 """
 
 from __future__ import annotations

--- a/mlgym/backend/debugging.py
+++ b/mlgym/backend/debugging.py
@@ -16,7 +16,7 @@ import json
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar
 
-from mlgym.backend.base import BaseModel, ModelArguments
+from mlgym.backend.base import BaseModel, ModelConfig
 from mlgym.types import HistoryItem
 
 if TYPE_CHECKING:
@@ -30,7 +30,7 @@ class SubmitBaselineModel(BaseModel):
 
     MODELS: ClassVar = {"submit_baseline": {}}
 
-    def __init__(self, args: ModelArguments) -> None:
+    def __init__(self, args: ModelConfig) -> None:
         """
         This model immediately submits. Useful for testing
         """
@@ -91,7 +91,7 @@ class SubmitBaselineWrongModel(BaseModel):
 
     MODELS: ClassVar = {"submit_baseline_wrong": {}}
 
-    def __init__(self, args: ModelArguments) -> None:
+    def __init__(self, args: ModelConfig) -> None:
         """
         This model immediately submits. Useful for testing
         """
@@ -120,7 +120,7 @@ class ReplayModel(BaseModel):
 
     MODELS: ClassVar = {"replay": {}}
 
-    def __init__(self, args: ModelArguments) -> None:
+    def __init__(self, args: ModelConfig) -> None:
         super().__init__(args)
 
         if self.args.replay_path is None or not Path(self.args.replay_path).exists():

--- a/mlgym/backend/debugging.py
+++ b/mlgym/backend/debugging.py
@@ -16,8 +16,10 @@ import json
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar
 
-from mlgym.backend.base import BaseModel, ModelConfig
+from mlgym.backend.base import BaseModel
 from mlgym.types import HistoryItem
+
+from mlgym.backend.config import ModelConfig
 
 if TYPE_CHECKING:
     from mlgym.types import HistoryItem

--- a/mlgym/backend/human.py
+++ b/mlgym/backend/human.py
@@ -11,8 +11,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, ClassVar
 
-from mlgym.backend.base import BaseModel, ModelConfig
+from mlgym.backend.base import BaseModel
 from mlgym.types import HistoryItem
+
+from mlgym.backend.config import ModelConfig
 
 if TYPE_CHECKING:
     from mlgym.tools.commands import Command

--- a/mlgym/backend/human.py
+++ b/mlgym/backend/human.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, ClassVar
 
-from mlgym.backend.base import BaseModel, ModelArguments
+from mlgym.backend.base import BaseModel, ModelConfig
 from mlgym.types import HistoryItem
 
 if TYPE_CHECKING:
@@ -26,7 +26,7 @@ class HumanModel(BaseModel):
 
     MODELS: ClassVar = {"human": {}}
 
-    def __init__(self, args: ModelArguments, commands: list[Command]) -> None:
+    def __init__(self, args: ModelConfig, commands: list[Command]) -> None:
         super().__init__(args)
 
         # Determine which commands require multi-line input

--- a/mlgym/backend/litellm.py
+++ b/mlgym/backend/litellm.py
@@ -24,8 +24,10 @@ from tenacity import (
 )
 
 from mlgym.backend import _MAX_RETRIES
-from mlgym.backend.base import BaseModel, ModelConfig
+from mlgym.backend.base import BaseModel
 from mlgym.exceptions import ContextWindowExceededError, CostLimitExceededError
+
+from mlgym.backend.config import ModelConfig
 
 if TYPE_CHECKING:
     from mlgym.types import HistoryItem

--- a/mlgym/backend/litellm.py
+++ b/mlgym/backend/litellm.py
@@ -24,7 +24,7 @@ from tenacity import (
 )
 
 from mlgym.backend import _MAX_RETRIES
-from mlgym.backend.base import BaseModel, ModelArguments
+from mlgym.backend.base import BaseModel, ModelConfig
 from mlgym.exceptions import ContextWindowExceededError, CostLimitExceededError
 
 if TYPE_CHECKING:
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 
 
 class LiteLLMModel(BaseModel):
-    def __init__(self, args: ModelArguments) -> None:
+    def __init__(self, args: ModelConfig) -> None:
         """Model served by the `litellm` library."""
         super().__init__(args)
 

--- a/mlgym/backend/utils.py
+++ b/mlgym/backend/utils.py
@@ -17,12 +17,12 @@ from mlgym.backend.human import HumanModel, HumanThoughtModel
 from mlgym.backend.litellm import LiteLLMModel
 
 if TYPE_CHECKING:
-    from mlgym.backend.base import BaseModel, ModelArguments
+    from mlgym.backend.base import BaseModel, ModelConfig
     from mlgym.tools.commands import Command
 
 
 # ! TODO: Add a meta model class so that we can register custom model classes on the fly.
-def get_model(args: ModelArguments, commands: list[Command] | None = None) -> BaseModel:
+def get_model(args: ModelConfig, commands: list[Command] | None = None) -> BaseModel:
     """
     Returns correct model object given arguments and commands
     """

--- a/mlgym/backend/utils.py
+++ b/mlgym/backend/utils.py
@@ -17,8 +17,10 @@ from mlgym.backend.human import HumanModel, HumanThoughtModel
 from mlgym.backend.litellm import LiteLLMModel
 
 if TYPE_CHECKING:
-    from mlgym.backend.base import BaseModel, ModelConfig
+    from mlgym.backend.base import BaseModel
     from mlgym.tools.commands import Command
+    
+    from mlgym.backend.config import ModelConfig
 
 
 # ! TODO: Add a meta model class so that we can register custom model classes on the fly.

--- a/mlgym/cli/arguments/agent.py
+++ b/mlgym/cli/arguments/agent.py
@@ -22,7 +22,7 @@ from simple_parsing.helpers.serialization.serializable import FrozenSerializable
 from mlgym.agent.config import AgentConfig
 
 if TYPE_CHECKING:
-    from mlgym.backend.base import ModelConfig
+    from mlgym.backend.config import ModelConfig
 
 
 @dataclass(frozen=True)

--- a/mlgym/cli/arguments/agent.py
+++ b/mlgym/cli/arguments/agent.py
@@ -1,0 +1,45 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+Base agent implementation for the MLGym framework.
+
+This module provides the core agent functionality including configuration,
+history tracking, model interaction, and environment communication. The agent
+is responsible for receiving observations from the environment, querying the
+model for actions, and executing those actions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from simple_parsing.helpers.fields import field
+from simple_parsing.helpers.flatten import FlattenedAccess
+from simple_parsing.helpers.serialization.serializable import FrozenSerializable
+
+from mlgym.agent.config import AgentConfig
+
+if TYPE_CHECKING:
+    from mlgym.backend.base import ModelConfig
+
+
+@dataclass(frozen=True)
+class AgentArguments(FlattenedAccess, FrozenSerializable):
+    """Configure the agent's behaviour (templates, parse functions, ...)."""
+
+    model: ModelConfig
+
+    # Policy can only be set via config yaml file from command line
+    agent_config_path: Path | str | None = None
+    # FIXME: Migrate to pydantic under issue #19
+    config: AgentConfig | None = field(default=None, cmd=False)  # noqa: RUF009
+    log_verbose_to_console: bool = False
+
+    def __post_init__(self) -> None:
+        if self.config is None and self.agent_config_path is not None:
+            # If unassigned, we load the config from the file to store its contents with the overall arguments
+            config = AgentConfig.load_yaml(self.agent_config_path)
+            object.__setattr__(self, "config", config)
+        assert self.config is not None

--- a/mlgym/cli/arguments/agent.py
+++ b/mlgym/cli/arguments/agent.py
@@ -1,12 +1,10 @@
 """
 Copyright (c) Meta Platforms, Inc. and affiliates.
 
-Base agent implementation for the MLGym framework.
+CLI Arguments for creating agent.
 
-This module provides the core agent functionality including configuration,
-history tracking, model interaction, and environment communication. The agent
-is responsible for receiving observations from the environment, querying the
-model for actions, and executing those actions.
+This module defines the necessary arguments that must be
+defined when running MLGym as a CLI tool.
 """
 
 from __future__ import annotations

--- a/mlgym/environment/config.py
+++ b/mlgym/environment/config.py
@@ -1,12 +1,9 @@
 """
 Copyright (c) Meta Platforms, Inc. and affiliates.
 
-Core environment implementation for the MLGym framework.
+Config module for environment module.
 
-This module provides the main environment class and supporting functionality for
-running machine learning tasks. It handles container management, task execution,
-file operations, and agent interactions. The environment supports various task types
-and manages the workspace, evaluation, and resource limits.
+This module provides the configuration interface for the environment module.
 """
 
 from __future__ import annotations

--- a/mlgym/environment/config.py
+++ b/mlgym/environment/config.py
@@ -1,0 +1,115 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+Core environment implementation for the MLGym framework.
+
+This module provides the main environment class and supporting functionality for
+running machine learning tasks. It handles container management, task execution,
+file operations, and agent interactions. The environment supports various task types
+and manages the workspace, evaluation, and resource limits.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+from simple_parsing import choice
+from simple_parsing.helpers.flatten import FlattenedAccess
+from simple_parsing.helpers.serialization.serializable import FrozenSerializable
+
+from mlgym import CONFIG_DIR
+from mlgym.environment.tasks import (
+    AbstractMLTask,
+    TaskConfig,
+)
+from mlgym.utils.extras import multiline_representer
+
+yaml.add_representer(str, multiline_representer)
+yaml.representer.SafeRepresenter.add_representer(str, multiline_representer)  # type: ignore
+
+
+@dataclass(frozen=True)
+class EnvironmentConfig(FlattenedAccess, FrozenSerializable):
+    """
+    Configuration for the MLGym environment.
+    One env is always related to a single task.
+    """
+
+    # Name of the docker image to use for the environment. Defaults to mlgym/mlgym-agent:latest
+    image_name: str = "aigym/mlgym-agent:latest"
+    # maximum number of agent steps in the environment
+    max_steps: int = 100
+    # random seed
+    seed: int = 42
+    # ! TODO: Should be moved to ScriptArguments along with benchmark config
+    # can be set by the user if evaluation should be done on a single task
+    # accepts a TaskConfig object or a path to a yaml file relative to the CONFIG_DIR
+    task_config_path: Path | str | None = None
+    # task config object
+    task: TaskConfig | None = None
+    # container type to use. options are "docker"
+    container_type: str = choice("docker", "podman", default="docker")
+    # * CURRENTLY NOT USED
+    # Only used for docker container. Use a persistent container with this name. After every task, the container will be paused, but not removed.
+    container_name: str | None = None
+    # Enable environment logger.
+    verbose: bool = False
+    # cache baseline scores for each dataset
+    cache_baseline_scores: bool = True
+    # * CURRENTLY NOT USED
+    # Cache task images to speed up task initialization. This means that the environment will be saved as a docker image.
+    cache_task_images: bool = False
+    # * CURRENTLY NOT USED
+    # Custom environment setup. Currently only used when running on a single task.
+    # This needs to be either a string pointing to a yaml file (with yaml, yml file extension)
+    # or a shell script (with sh extension). Generally this can be used to setup custom conda environments or docker containers for a task.
+    environment_setup: str | None = None
+    # Enable memory
+    memory_enabled: bool = False
+    # * CURRENTLY NOT USED
+    # Container mounts = addiitonal folders to mount into the environment (useful for caching)
+    container_mounts: list[str] = field(default_factory=list)
+    # Path to the bash aliases file to source in the container
+    aliases_file: str | None = None
+
+    def get_task_class(self) -> type[AbstractMLTask]:
+        """
+        Get the task class based on the task configuration.
+
+        Returns:
+            type[AbstractMLTask]: Task class to instantiate
+
+        Raises:
+            AssertionError: If task is not set
+        """
+        assert isinstance(self.task, TaskConfig)
+        return AbstractMLTask.get(self.task.task_entrypoint)
+
+    def __post_init__(self) -> None:
+        """
+        Validate and process configuration after initialization.
+
+        Raises:
+            ValueError: If task_config_path is not provided
+            ValueError: If cache_task_images and container_name are both set
+            ValueError: If container_name is empty string
+        """
+        if self.task_config_path is None:
+            msg = "You must provide a Task Config to the environment. Please provide a "
+            raise ValueError(msg)
+
+        # always load the task config from the path
+        object.__setattr__(self, "task", TaskConfig.load_yaml(CONFIG_DIR / self.task_config_path))
+
+        if self.cache_task_images and self.container_name:
+            msg = (
+                "Not allowed to use persistent container with caching task images "
+                "(probably doesn't make sense and takes excessive space)."
+            )
+            raise ValueError(msg)
+        if self.container_name is not None and self.container_name.strip() == "":
+            msg = "Set container_name to None if you don't want to use a persistent container."
+            raise ValueError(msg)
+

--- a/mlgym/environment/config.py
+++ b/mlgym/environment/config.py
@@ -20,11 +20,11 @@ from simple_parsing.helpers.flatten import FlattenedAccess
 from simple_parsing.helpers.serialization.serializable import FrozenSerializable
 
 from mlgym import CONFIG_DIR
-from mlgym.environment.tasks import (
-    AbstractMLTask,
-    TaskConfig,
-)
+from mlgym.environment.tasks import AbstractMLTask
+
 from mlgym.utils.extras import multiline_representer
+
+from mlgym.environment.task_config import TaskConfig
 
 yaml.add_representer(str, multiline_representer)
 yaml.representer.SafeRepresenter.add_representer(str, multiline_representer)  # type: ignore

--- a/mlgym/environment/env.py
+++ b/mlgym/environment/env.py
@@ -82,7 +82,7 @@ yaml.representer.SafeRepresenter.add_representer(str, multiline_representer)  # 
 
 
 @dataclass(frozen=True)
-class EnvironmentArguments(FlattenedAccess, FrozenSerializable):
+class EnvironmentConfig(FlattenedAccess, FrozenSerializable):
     """
     Configuration for the MLGym environment.
     One env is always related to a single task.
@@ -186,7 +186,7 @@ class MLGymEnv(gym.Env):
 
     def __init__(
         self,
-        args: EnvironmentArguments,
+        args: EnvironmentConfig,
         devices: list[str],
         render_mode: str | None = None,
     ) -> None:
@@ -205,7 +205,7 @@ class MLGymEnv(gym.Env):
         t0 = time.perf_counter()
         assert render_mode is None or render_mode in self.metadata["render_modes"]
 
-        self.args: EnvironmentArguments = args
+        self.args: EnvironmentConfig = args
         self.task_args: TaskConfig = args.task  # type: ignore
         self.communicate_output: str | None = None
         self.container_name: str | None = args.container_name

--- a/mlgym/environment/env.py
+++ b/mlgym/environment/env.py
@@ -22,7 +22,6 @@ import os
 import re
 import shlex
 import time
-from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -31,18 +30,13 @@ import docker.models.containers
 import gymnasium as gym
 import yaml
 from docker.errors import DockerException, NotFound
-from simple_parsing import choice
-from simple_parsing.helpers.flatten import FlattenedAccess
-from simple_parsing.helpers.serialization.serializable import FrozenSerializable
 
 from mlgym import CONFIG_DIR, REPO_ROOT
 from mlgym.environment.spaces import Unicode
 from mlgym.environment.tasks import (
     AbstractMLTask,
-    DatasetConfig,
     EvaluationFormatError,
     SubmissionNotFoundError,
-    TaskConfig,
 )
 from mlgym.environment.utils import (
     PROCESS_DONE_MARKER_END,
@@ -59,6 +53,12 @@ from mlgym.environment.utils import (
 from mlgym.types import AgentInfo
 from mlgym.utils.extras import multiline_representer
 from mlgym.utils.log import get_logger
+
+from mlgym.environment.config import EnvironmentConfig
+from mlgym.environment.task_config import (
+    TaskConfig,
+    DatasetConfig,
+)
 
 if TYPE_CHECKING:
     import subprocess
@@ -79,90 +79,6 @@ TRAIN_COMMANDS = ["torchrun", "python", "python3", "accelerate", "deepspeed"]
 
 yaml.add_representer(str, multiline_representer)
 yaml.representer.SafeRepresenter.add_representer(str, multiline_representer)  # type: ignore
-
-
-@dataclass(frozen=True)
-class EnvironmentConfig(FlattenedAccess, FrozenSerializable):
-    """
-    Configuration for the MLGym environment.
-    One env is always related to a single task.
-    """
-
-    # Name of the docker image to use for the environment. Defaults to mlgym/mlgym-agent:latest
-    image_name: str = "aigym/mlgym-agent:latest"
-    # maximum number of agent steps in the environment
-    max_steps: int = 100
-    # random seed
-    seed: int = 42
-    # ! TODO: Should be moved to ScriptArguments along with benchmark config
-    # can be set by the user if evaluation should be done on a single task
-    # accepts a TaskConfig object or a path to a yaml file relative to the CONFIG_DIR
-    task_config_path: Path | str | None = None
-    # task config object
-    task: TaskConfig | None = None
-    # container type to use. options are "docker"
-    container_type: str = choice("docker", "podman", default="docker")
-    # * CURRENTLY NOT USED
-    # Only used for docker container. Use a persistent container with this name. After every task, the container will be paused, but not removed.
-    container_name: str | None = None
-    # Enable environment logger.
-    verbose: bool = False
-    # cache baseline scores for each dataset
-    cache_baseline_scores: bool = True
-    # * CURRENTLY NOT USED
-    # Cache task images to speed up task initialization. This means that the environment will be saved as a docker image.
-    cache_task_images: bool = False
-    # * CURRENTLY NOT USED
-    # Custom environment setup. Currently only used when running on a single task.
-    # This needs to be either a string pointing to a yaml file (with yaml, yml file extension)
-    # or a shell script (with sh extension). Generally this can be used to setup custom conda environments or docker containers for a task.
-    environment_setup: str | None = None
-    # Enable memory
-    memory_enabled: bool = False
-    # * CURRENTLY NOT USED
-    # Container mounts = addiitonal folders to mount into the environment (useful for caching)
-    container_mounts: list[str] = field(default_factory=list)
-    # Path to the bash aliases file to source in the container
-    aliases_file: str | None = None
-
-    def get_task_class(self) -> type[AbstractMLTask]:
-        """
-        Get the task class based on the task configuration.
-
-        Returns:
-            type[AbstractMLTask]: Task class to instantiate
-
-        Raises:
-            AssertionError: If task is not set
-        """
-        assert isinstance(self.task, TaskConfig)
-        return AbstractMLTask.get(self.task.task_entrypoint)
-
-    def __post_init__(self) -> None:
-        """
-        Validate and process configuration after initialization.
-
-        Raises:
-            ValueError: If task_config_path is not provided
-            ValueError: If cache_task_images and container_name are both set
-            ValueError: If container_name is empty string
-        """
-        if self.task_config_path is None:
-            msg = "You must provide a Task Config to the environment. Please provide a "
-            raise ValueError(msg)
-
-        # always load the task config from the path
-        object.__setattr__(self, "task", TaskConfig.load_yaml(CONFIG_DIR / self.task_config_path))
-
-        if self.cache_task_images and self.container_name:
-            msg = (
-                "Not allowed to use persistent container with caching task images "
-                "(probably doesn't make sense and takes excessive space)."
-            )
-            raise ValueError(msg)
-        if self.container_name is not None and self.container_name.strip() == "":
-            msg = "Set container_name to None if you don't want to use a persistent container."
-            raise ValueError(msg)
 
 
 class MLGymEnv(gym.Env):

--- a/mlgym/environment/registration.py
+++ b/mlgym/environment/registration.py
@@ -13,7 +13,9 @@ from typing import Any
 
 import gymnasium as gym
 
-from mlgym.environment.env import EnvironmentConfig, MLGymEnv
+from mlgym.environment.env import MLGymEnv
+
+from mlgym.environment.config import EnvironmentConfig
 
 
 # FIXME: Registration logic is completely broken. Move this to the environment class maybe or add a registration module that depends only on the environment. Task based registration is not needed.

--- a/mlgym/environment/registration.py
+++ b/mlgym/environment/registration.py
@@ -13,11 +13,11 @@ from typing import Any
 
 import gymnasium as gym
 
-from mlgym.environment.env import EnvironmentArguments, MLGymEnv
+from mlgym.environment.env import EnvironmentConfig, MLGymEnv
 
 
 # FIXME: Registration logic is completely broken. Move this to the environment class maybe or add a registration module that depends only on the environment. Task based registration is not needed.
-def register_task(env_config: EnvironmentArguments, *args: Any, nondeterministic: bool = True, **kwargs: Any) -> None:  # noqa: ANN401
+def register_task(env_config: EnvironmentConfig, *args: Any, nondeterministic: bool = True, **kwargs: Any) -> None:  # noqa: ANN401
     """
     Registers a ML task as a gym environment with its unique id.
 

--- a/mlgym/environment/task_config.py
+++ b/mlgym/environment/task_config.py
@@ -1,12 +1,9 @@
 """
 Copyright (c) Meta Platforms, Inc. and affiliates.
 
-Tasks for Gymnasium environments.
+Config module for task module.
 
-This module provides the base class for defining ML tasks and a set of concrete task classes
-for different types of ML tasks. It handles task configuration, evaluation, baseline execution,
-and submission processing for various ML task types including CSV submissions, model submissions,
-and language model tasks.
+This module provides the configuration interface for the task module.
 """
 
 from __future__ import annotations

--- a/mlgym/environment/task_config.py
+++ b/mlgym/environment/task_config.py
@@ -1,0 +1,136 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+Tasks for Gymnasium environments.
+
+This module provides the base class for defining ML tasks and a set of concrete task classes
+for different types of ML tasks. It handles task configuration, evaluation, baseline execution,
+and submission processing for various ML task types including CSV submissions, model submissions,
+and language model tasks.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+from simple_parsing.helpers.fields import field
+from simple_parsing.helpers.serialization import encode
+from simple_parsing.helpers.serialization.serializable import (
+    FrozenSerializable,
+    Serializable,
+)
+
+from mlgym import CONFIG_DIR
+from mlgym.utils.extras import multiline_representer
+
+AGENT_LONG_ACTION_TIMEOUT = int(os.getenv("MLGYM_AGENT_LONG_TIMEOUT", "3600"))
+
+@dataclass(frozen=True)
+class SplitConfig(FrozenSerializable):
+    """
+    Configuration for a dataset split.
+    """
+
+    name: str  # split name
+    file_regex: str  # regex to match files in the split
+
+
+@dataclass(frozen=True)
+class DatasetConfig(FrozenSerializable):
+    """
+    Configuration for a dataset.
+    """
+
+    name: str  # name of the datasets
+    description: str  # description of the dataset format
+    # local path or huggingface repo id of the dataset
+    # local path should be relative to the REPO_ROOT
+    data_path: str
+    # indicates if dataset files are stored locally. If true, data_path must point to a valid filesystem directory
+    is_local: bool = False
+    train_split: SplitConfig | None = None
+    valid_split: SplitConfig | None = None
+    test_split: SplitConfig | None = None
+
+# FIXME: All RUF009 should be resolved as part of issue #19.
+@dataclass
+class TaskConfig(Serializable):
+    """
+    Configuration for a MLGym task. A task can be tied to a single dataset or multiple datasets.
+    """
+
+    id: str  # text identifier for the task. Will be used to register the task with the gym environment
+    name: str  # name of the task
+    description: str  # description/goal of the task
+    # list of paths to the dataset config files
+    # paths should be relative to the CONFIG_DIR
+    dataset_configs: list[str] = field(default_factory=list)  # noqa: RUF009
+
+    _datasets: list[DatasetConfig] = field(default_factory=list, init=False)  # noqa: RUF009
+    # task class to use to instantiate the task
+    task_entrypoint: str = "CSVSubmissionTasks"
+    # maximum time (in seconds) allowed for each training run
+    training_timeout: int | None = None
+    # path to a requirements.txt file for creating a task specific conda environment
+    requirements_path: Path | str | None = None
+    # benchmark name to associate with the task. If None, the task will not be registered with a benchmark
+    benchmark_name: str | None = None
+    # use the default mlgym conda environment
+    use_generic_conda: bool = True
+    # TODO: maybe these should be tied to the dataset name as a dictionary?
+    # TODO: we can create a baseline_config class that contains the baseline_path, baseline_score and dataset_name. But at this point do we really want to create a new config class? This might overload the user.
+    # ASSUMPTION: the baseline_paths and baseline_scores are provided in the same order as the datasets
+    # path to the starter code files for this task. This can include baseline code, evaluation script, any other local libraries etc.
+    starter_code: list[str] = field(default_factory=list)  # noqa: RUF009
+    # path to a baseline script for this task. This path should be relative to the `data/<task_name>` directory. Eg: for rlMountainCarContinuous, the path should be `baseline/train.py`.
+    baseline_paths: list[Path | str] = field(default_factory=list)  # noqa: RUF009
+    # baseline scrores for each dataset. If None, the baseline scores will be computed using the baseline scripts
+    baseline_scores: list[dict[str, float]] = field(default_factory=list)  # noqa: RUF009
+    # path to a sample submission file for the task
+    sample_submission: Path | str | None = None
+    # path to an evaluation script for the task. This path should be relative to the `data/<task_name>` directory. Eg: for rlMountainCarContinuous, the path should be `evaluate.py`.
+    evaluation_paths: list[Path | str] = field(default_factory=list)  # noqa: RUF009
+    # read-only flag for the evaluation script. If True, the agent will not have write access to the evaluation script. NOTE: This can cause evaluation script to fail but makes the evaluation more robust to agent's actions. USE IT AT YOUR OWN RISK.
+    evaluation_read_only: bool = False
+    # ! TODO: NOT IMPLEMENTED YET.
+    # list of files where the agent should not have any access to. This is useful for cases like battle of sexes where the agent should not be able to peak into the target strategy.
+    secret_files: list[Path | str] = field(default_factory=list)  # noqa: RUF009
+    # path to a memory file for the task. This file will be used to store the task's memory.
+    memory_path: Path | str | None = None
+
+    # FIXME: use dump_yaml from superclass with a dump_fn argument.
+    def dump_yaml(self, stream, **kwargs: Any) -> str:  # type: ignore # noqa: ANN001, ANN401
+        # add multiline representer for description
+        yaml.add_representer(str, multiline_representer)
+        yaml.representer.SafeRepresenter.add_representer(str, multiline_representer)  # type: ignore
+
+        data = encode(self)
+        # Remove None values
+        data = {k: v for k, v in data.items() if (k != "_datasets" and v is not None and v != [] and v != {})}
+        return yaml.safe_dump(data, stream, **kwargs)  # type: ignore
+
+    def __post_init__(self) -> None:
+        # load dataset configs from paths
+        if len(self.dataset_configs) > 0:
+            datasets = []
+            for path in self.dataset_configs:
+                dataset_config_path = CONFIG_DIR / path
+                if not dataset_config_path.exists():
+                    msg = f"Dataset config file not found at {dataset_config_path}"
+                    raise FileNotFoundError(msg)
+                datasets.append(DatasetConfig.load_yaml(dataset_config_path))
+            object.__setattr__(self, "_datasets", datasets)
+
+        if self.sample_submission is not None and not Path(self.sample_submission).exists():
+            msg = f"Sample submission path provided but file not found at {self.sample_submission}"
+            raise FileNotFoundError(msg)
+
+        # check if requirements_path is provided if use_generic_conda is False
+        if not self.use_generic_conda and (self.requirements_path is None or not Path(self.requirements_path).exists()):
+            msg = "Requirements path must be provided if use_generic_conda is False"
+            raise ValueError(msg)
+

--- a/mlgym/environment/tasks.py
+++ b/mlgym/environment/tasks.py
@@ -15,22 +15,14 @@ from __future__ import annotations
 import json
 import os
 from abc import abstractmethod
-from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar
 
 import numpy as np
-import yaml
-from simple_parsing.helpers.fields import field
-from simple_parsing.helpers.serialization import encode
-from simple_parsing.helpers.serialization.serializable import (
-    FrozenSerializable,
-    Serializable,
-)
 
-from mlgym import CONFIG_DIR
-from mlgym.utils.extras import multiline_representer
 from mlgym.utils.log import get_logger
+
+from mlgym.environment.task_config import TaskConfig
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -52,113 +44,6 @@ class EvaluationFormatError(Exception):
     """
 
     pass
-
-
-@dataclass(frozen=True)
-class SplitConfig(FrozenSerializable):
-    """
-    Configuration for a dataset split.
-    """
-
-    name: str  # split name
-    file_regex: str  # regex to match files in the split
-
-
-@dataclass(frozen=True)
-class DatasetConfig(FrozenSerializable):
-    """
-    Configuration for a dataset.
-    """
-
-    name: str  # name of the datasets
-    description: str  # description of the dataset format
-    # local path or huggingface repo id of the dataset
-    # local path should be relative to the REPO_ROOT
-    data_path: str
-    # indicates if dataset files are stored locally. If true, data_path must point to a valid filesystem directory
-    is_local: bool = False
-    train_split: SplitConfig | None = None
-    valid_split: SplitConfig | None = None
-    test_split: SplitConfig | None = None
-
-
-# FIXME: All RUF009 should be resolved as part of issue #19.
-@dataclass
-class TaskConfig(Serializable):
-    """
-    Configuration for a MLGym task. A task can be tied to a single dataset or multiple datasets.
-    """
-
-    id: str  # text identifier for the task. Will be used to register the task with the gym environment
-    name: str  # name of the task
-    description: str  # description/goal of the task
-    # list of paths to the dataset config files
-    # paths should be relative to the CONFIG_DIR
-    dataset_configs: list[str] = field(default_factory=list)  # noqa: RUF009
-
-    _datasets: list[DatasetConfig] = field(default_factory=list, init=False)  # noqa: RUF009
-    # task class to use to instantiate the task
-    task_entrypoint: str = "CSVSubmissionTasks"
-    # maximum time (in seconds) allowed for each training run
-    training_timeout: int | None = None
-    # path to a requirements.txt file for creating a task specific conda environment
-    requirements_path: Path | str | None = None
-    # benchmark name to associate with the task. If None, the task will not be registered with a benchmark
-    benchmark_name: str | None = None
-    # use the default mlgym conda environment
-    use_generic_conda: bool = True
-    # TODO: maybe these should be tied to the dataset name as a dictionary?
-    # TODO: we can create a baseline_config class that contains the baseline_path, baseline_score and dataset_name. But at this point do we really want to create a new config class? This might overload the user.
-    # ASSUMPTION: the baseline_paths and baseline_scores are provided in the same order as the datasets
-    # path to the starter code files for this task. This can include baseline code, evaluation script, any other local libraries etc.
-    starter_code: list[str] = field(default_factory=list)  # noqa: RUF009
-    # path to a baseline script for this task. This path should be relative to the `data/<task_name>` directory. Eg: for rlMountainCarContinuous, the path should be `baseline/train.py`.
-    baseline_paths: list[Path | str] = field(default_factory=list)  # noqa: RUF009
-    # baseline scrores for each dataset. If None, the baseline scores will be computed using the baseline scripts
-    baseline_scores: list[dict[str, float]] = field(default_factory=list)  # noqa: RUF009
-    # path to a sample submission file for the task
-    sample_submission: Path | str | None = None
-    # path to an evaluation script for the task. This path should be relative to the `data/<task_name>` directory. Eg: for rlMountainCarContinuous, the path should be `evaluate.py`.
-    evaluation_paths: list[Path | str] = field(default_factory=list)  # noqa: RUF009
-    # read-only flag for the evaluation script. If True, the agent will not have write access to the evaluation script. NOTE: This can cause evaluation script to fail but makes the evaluation more robust to agent's actions. USE IT AT YOUR OWN RISK.
-    evaluation_read_only: bool = False
-    # ! TODO: NOT IMPLEMENTED YET.
-    # list of files where the agent should not have any access to. This is useful for cases like battle of sexes where the agent should not be able to peak into the target strategy.
-    secret_files: list[Path | str] = field(default_factory=list)  # noqa: RUF009
-    # path to a memory file for the task. This file will be used to store the task's memory.
-    memory_path: Path | str | None = None
-
-    # FIXME: use dump_yaml from superclass with a dump_fn argument.
-    def dump_yaml(self, stream, **kwargs: Any) -> str:  # type: ignore # noqa: ANN001, ANN401
-        # add multiline representer for description
-        yaml.add_representer(str, multiline_representer)
-        yaml.representer.SafeRepresenter.add_representer(str, multiline_representer)  # type: ignore
-
-        data = encode(self)
-        # Remove None values
-        data = {k: v for k, v in data.items() if (k != "_datasets" and v is not None and v != [] and v != {})}
-        return yaml.safe_dump(data, stream, **kwargs)  # type: ignore
-
-    def __post_init__(self) -> None:
-        # load dataset configs from paths
-        if len(self.dataset_configs) > 0:
-            datasets = []
-            for path in self.dataset_configs:
-                dataset_config_path = CONFIG_DIR / path
-                if not dataset_config_path.exists():
-                    msg = f"Dataset config file not found at {dataset_config_path}"
-                    raise FileNotFoundError(msg)
-                datasets.append(DatasetConfig.load_yaml(dataset_config_path))
-            object.__setattr__(self, "_datasets", datasets)
-
-        if self.sample_submission is not None and not Path(self.sample_submission).exists():
-            msg = f"Sample submission path provided but file not found at {self.sample_submission}"
-            raise FileNotFoundError(msg)
-
-        # check if requirements_path is provided if use_generic_conda is False
-        if not self.use_generic_conda and (self.requirements_path is None or not Path(self.requirements_path).exists()):
-            msg = "Requirements path must be provided if use_generic_conda is False"
-            raise ValueError(msg)
 
 
 class AbstractMLTaskMeta(type):

--- a/mlgym/tools/config.py
+++ b/mlgym/tools/config.py
@@ -1,0 +1,93 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+Core tools module for MLGym framework.
+
+This module provides tools for managing commands, environment variables, and
+command execution in the MLGym environment. It handles command parsing,
+blocklist enforcement, and multi-line command processing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from simple_parsing.helpers.fields import field
+from simple_parsing.helpers.flatten import FlattenedAccess
+from simple_parsing.helpers.serialization.serializable import FrozenSerializable
+
+from mlgym.tools.commands import Command
+from mlgym.tools.parsing import ParseCommand
+from mlgym.utils.config import convert_paths_to_abspath
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# FIXME: Fix as part of issue #19.
+@dataclass(frozen=True)
+class ToolsConfig(FlattenedAccess, FrozenSerializable):
+    command_files: list[str | Path] = field(default_factory=list)  # noqa: RUF009
+    env_variables: dict[str, str] = field(default_factory=dict)  # noqa: RUF009
+    util_functions: list[str] = field(default_factory=list)  # noqa: RUF009
+    submit_command: str = "submit"
+    parser: str | ParseCommand = "ParseCommandBash"
+    state_command: Command = Command(  # noqa: RUF009
+        name="state",
+        code="""state() {
+            echo '{"working_dir": "'$(realpath --relative-to=$ROOT/.. $PWD)'"}';
+        };""",
+    )
+    blocklist_error_template: str = "Interactive operation '{name}' is not supported by this environment"
+    blocklist: tuple[str, ...] = (
+        "vim",
+        "vi",
+        "emacs",
+        "nano",
+        "nohup",
+        "git",
+    )
+    blocklist_standalone: tuple[str, ...] = (
+        "python",
+        "python3",
+        "ipython",
+        "bash",
+        "sh",
+        "exit",
+        "/bin/bash",
+        "/bin/sh",
+        "nohup",
+        "vi",
+        "vim",
+        "emacs",
+        "nano",
+        "su",
+    )
+    commands: list[Command] = field(default_factory=list)  # noqa: RUF009
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "command_files", convert_paths_to_abspath(self.command_files))
+        if isinstance(self.parser, str):
+            object.__setattr__(self, "parser", ParseCommand.get(self.parser))
+        assert isinstance(self.parser, ParseCommand)
+
+        for file in self.command_files:
+            commands = self.parser.parse_command_file(str(file))
+
+            util_functions = [command for command in commands if command.name.startswith("_")]
+            commands = [command for command in commands if not command.name.startswith("_")]
+
+            object.__setattr__(self, "util_functions", self.util_functions + util_functions)
+            object.__setattr__(self, "commands", self.commands + commands)
+
+        multi_line_command_endings = {
+            command.name: command.end_name for command in self.commands if command.end_name is not None
+        }
+        object.__setattr__(self, "multi_line_command_endings", multi_line_command_endings)
+        command_docs = self.parser.generate_command_docs(
+            self.commands,
+            **self.env_variables,
+        )
+        object.__setattr__(self, "command_docs", command_docs)
+

--- a/mlgym/tools/config.py
+++ b/mlgym/tools/config.py
@@ -1,11 +1,9 @@
 """
 Copyright (c) Meta Platforms, Inc. and affiliates.
 
-Core tools module for MLGym framework.
+Config module for tools module.
 
-This module provides tools for managing commands, environment variables, and
-command execution in the MLGym environment. It handles command parsing,
-blocklist enforcement, and multi-line command processing.
+This module provides the configuration interface for the tools module.
 """
 
 from __future__ import annotations

--- a/mlgym/tools/tools.py
+++ b/mlgym/tools/tools.py
@@ -14,87 +14,10 @@ from __future__ import annotations
 
 import re
 from collections import defaultdict
-from dataclasses import dataclass
-from typing import TYPE_CHECKING
-
-from simple_parsing.helpers.fields import field
-from simple_parsing.helpers.flatten import FlattenedAccess
-from simple_parsing.helpers.serialization.serializable import FrozenSerializable
 
 from mlgym.tools.commands import Command
-from mlgym.tools.parsing import ParseCommand
-from mlgym.utils.config import convert_paths_to_abspath
 
-if TYPE_CHECKING:
-    from pathlib import Path
-
-
-# FIXME: Fix as part of issue #19.
-@dataclass(frozen=True)
-class ToolsConfig(FlattenedAccess, FrozenSerializable):
-    command_files: list[str | Path] = field(default_factory=list)  # noqa: RUF009
-    env_variables: dict[str, str] = field(default_factory=dict)  # noqa: RUF009
-    util_functions: list[str] = field(default_factory=list)  # noqa: RUF009
-    submit_command: str = "submit"
-    parser: str | ParseCommand = "ParseCommandBash"
-    state_command: Command = Command(  # noqa: RUF009
-        name="state",
-        code="""state() {
-            echo '{"working_dir": "'$(realpath --relative-to=$ROOT/.. $PWD)'"}';
-        };""",
-    )
-    blocklist_error_template: str = "Interactive operation '{name}' is not supported by this environment"
-    blocklist: tuple[str, ...] = (
-        "vim",
-        "vi",
-        "emacs",
-        "nano",
-        "nohup",
-        "git",
-    )
-    blocklist_standalone: tuple[str, ...] = (
-        "python",
-        "python3",
-        "ipython",
-        "bash",
-        "sh",
-        "exit",
-        "/bin/bash",
-        "/bin/sh",
-        "nohup",
-        "vi",
-        "vim",
-        "emacs",
-        "nano",
-        "su",
-    )
-    commands: list[Command] = field(default_factory=list)  # noqa: RUF009
-
-    def __post_init__(self) -> None:
-        object.__setattr__(self, "command_files", convert_paths_to_abspath(self.command_files))
-        if isinstance(self.parser, str):
-            object.__setattr__(self, "parser", ParseCommand.get(self.parser))
-        assert isinstance(self.parser, ParseCommand)
-
-        for file in self.command_files:
-            commands = self.parser.parse_command_file(str(file))
-
-            util_functions = [command for command in commands if command.name.startswith("_")]
-            commands = [command for command in commands if not command.name.startswith("_")]
-
-            object.__setattr__(self, "util_functions", self.util_functions + util_functions)
-            object.__setattr__(self, "commands", self.commands + commands)
-
-        multi_line_command_endings = {
-            command.name: command.end_name for command in self.commands if command.end_name is not None
-        }
-        object.__setattr__(self, "multi_line_command_endings", multi_line_command_endings)
-        command_docs = self.parser.generate_command_docs(
-            self.commands,
-            **self.env_variables,
-        )
-        object.__setattr__(self, "command_docs", command_docs)
-
+from mlgym.tools.config import ToolsConfig
 
 class ToolHandler:
     """

--- a/run.py
+++ b/run.py
@@ -26,12 +26,14 @@ from simple_parsing.helpers.serialization.serializable import FrozenSerializable
 
 from mlgym import CONFIG_DIR
 from mlgym.agent.base import AgentArguments, BaseAgent
-from mlgym.backend.base import ModelConfig
-from mlgym.environment.env import EnvironmentConfig, MLGymEnv
+from mlgym.environment.env import MLGymEnv
 from mlgym.environment.registration import register_task
 from mlgym.utils.config import load_environment_variables
 from mlgym.utils.extras import get_devices, multiline_representer
 from mlgym.utils.log import add_file_handler, get_logger
+
+from mlgym.backend.config import ModelConfig
+from mlgym.environment.config import EnvironmentConfig
 
 try:
     import rich  # noqa: F401

--- a/run.py
+++ b/run.py
@@ -26,8 +26,8 @@ from simple_parsing.helpers.serialization.serializable import FrozenSerializable
 
 from mlgym import CONFIG_DIR
 from mlgym.agent.base import AgentArguments, BaseAgent
-from mlgym.backend.base import ModelArguments
-from mlgym.environment.env import EnvironmentArguments, MLGymEnv
+from mlgym.backend.base import ModelConfig
+from mlgym.environment.env import EnvironmentConfig, MLGymEnv
 from mlgym.environment.registration import register_task
 from mlgym.utils.config import load_environment_variables
 from mlgym.utils.extras import get_devices, multiline_representer
@@ -62,7 +62,7 @@ logger.info(f"🍟 DOCKER_HOST: {os.environ.get('DOCKER_HOST')}")
 class ScriptArguments(FlattenedAccess, FrozenSerializable):
     """Configure the control flow of the run.py script"""
 
-    environment: EnvironmentArguments
+    environment: EnvironmentConfig
     agent: AgentArguments
     # if None, envArgs.task_args should be set to appropriate task config file
     benchmark: str | None = None
@@ -232,7 +232,7 @@ def get_args(args: list[str] | None = None) -> ScriptArguments:
         args: Optional list of arguments to parse. If not provided, uses sys.argv.
     """
     defaults = ScriptArguments(
-        environment=EnvironmentArguments(
+        environment=EnvironmentConfig(
             task_config_path="tasks/regressionKaggleHousePrice.yaml",
             max_steps=10,
             seed=42,
@@ -240,7 +240,7 @@ def get_args(args: list[str] | None = None) -> ScriptArguments:
             verbose=True,
         ),
         agent=AgentArguments(
-            model=ModelArguments(
+            model=ModelConfig(
                 model_name="litellm:gpt-4o",
                 total_cost_limit=0.0,
                 per_instance_cost_limit=3.0,


### PR DESCRIPTION
Changelog:
- Renamed `ModelArguments` to `ModelConfig`
- Renamed `EnvironmentArguments` to `EnvironmentConfig`

- Moved `AgentConfig` from `base/agent.py` to `base/configs.py`
- Moved `AgentArguments` from `base/agent.py` to `cli/arguments/agent.py`
- Moved `ModelConfig` from `backend/base.py` to `backend/config.py`
- Moved `EnvironmentConfig` from `environment/env.py` to `environment/config.py`
- Moved `TaskConfig` from `environment/tasks.py` to `environement/task_config.py`
- Moved `SplitConfig` from `environment/tasks.py` to `environement/task_config.py`
- Moved `DatasetConfig` from `environment/tasks.py` to `environement/task_config.py`
- Moved `ToolsConfig` from `tools/tools.py` to `tools/config.py`